### PR TITLE
CO: Fix for mysql duplicated id for guest account registration - guest is duplicated if it has multiple customer accounts

### DIFF
--- a/statsdata.php
+++ b/statsdata.php
@@ -169,7 +169,11 @@ class statsdata extends Module
             $params['cookie']->id_guest = $guest->id;
         } else {
             // The guest is duplicated if it has multiple customer accounts
-            $method = ($guest->id_customer) ? 'add' : 'update';
+            $method = 'update';
+            if ($guest->id_customer) {
+                $method = 'add';
+                $guest->id = null;
+            }
             $guest->id_customer = $params['cookie']->id_customer;
             $guest->{$method}();
         }


### PR DESCRIPTION
Fix for a situation when a new registration as Guest occurs for someone who has already a Guest account registered. You've got a MySQL error for a duplicated ID because it tries to create a new guest record with the same id.