### PR TITLE
Fix statistics error

### DIFF
--- a/statsdata.php
+++ b/statsdata.php
@@ -135,15 +135,15 @@ class statsdata extends Module
 				$(window).unload(
 					function() {
 						var time_end = new Date();
-						var pagetime = new Object;
-						pagetime.type = "pagetime";
-						pagetime.id_connections = "' . (int) $token_array['id_connections'] . '";
-						pagetime.id_page = "' . (int) $token_array['id_page'] . '";
-						pagetime.time_start = "' . $token_array['time_start'] . '";
-						pagetime.token = "' . $token . '";
-						pagetime.time = time_end-time_start;
-						pagetime.ajax = "1";
-						$.post("' . Context::getContext()->link->getPageLink('statistics', (bool) (Tools::getShopProtocol() == 'https://')) . '", pagetime);
+                        var pagetime = new FormData();
+                        pagetime.append("type", "pagetime");
+                        pagetime.append("id_connections", "'.(int)$token_array['id_connections'].'");
+                        pagetime.append("id_page", "'.(int)$token_array['id_page'].'");
+                        pagetime.append("time_start", "'.$token_array['time_start'].'");
+                        pagetime.append("token", "'.$token.'");
+                        pagetime.append("time", time_end-time_start);
+                        pagetime.append("ajax", "1");
+                        navigator.sendBeacon("'.Context::getContext()->link->getPageLink('statistics', (bool)(Tools::getShopProtocol() == 'https://')).'", pagetime);
 					}
 				);
 			</script>';

--- a/statsdata.php
+++ b/statsdata.php
@@ -102,6 +102,7 @@ class statsdata extends Module
 						navinfo.type = "navinfo";
 						navinfo.id_guest = "' . (int) $params['cookie']->id_guest . '";
 						navinfo.token = "' . $token . '";
+						navinfo.ajax = "1";
 						$.post("' . Context::getContext()->link->getPageLink('statistics', (bool) (Tools::getShopProtocol() == 'https://')) . '", navinfo);
 					});
 				</script>';
@@ -141,6 +142,7 @@ class statsdata extends Module
 						pagetime.time_start = "' . $token_array['time_start'] . '";
 						pagetime.token = "' . $token . '";
 						pagetime.time = time_end-time_start;
+						pagetime.ajax = "1";
 						$.post("' . Context::getContext()->link->getPageLink('statistics', (bool) (Tools::getShopProtocol() == 'https://')) . '", pagetime);
 					}
 				);

--- a/statsdata.php
+++ b/statsdata.php
@@ -135,15 +135,15 @@ class statsdata extends Module
 				$(window).unload(
 					function() {
 						var time_end = new Date();
-                        var pagetime = new FormData();
-                        pagetime.append("type", "pagetime");
-                        pagetime.append("id_connections", "'.(int)$token_array['id_connections'].'");
-                        pagetime.append("id_page", "'.(int)$token_array['id_page'].'");
-                        pagetime.append("time_start", "'.$token_array['time_start'].'");
-                        pagetime.append("token", "'.$token.'");
-                        pagetime.append("time", time_end-time_start);
-                        pagetime.append("ajax", "1");
-                        navigator.sendBeacon("'.Context::getContext()->link->getPageLink('statistics', (bool)(Tools::getShopProtocol() == 'https://')).'", pagetime);
+						var pagetime = new FormData();
+						pagetime.append("type", "pagetime");
+						pagetime.append("id_connections", "'.(int)$token_array['id_connections'].'");
+						pagetime.append("id_page", "'.(int)$token_array['id_page'].'");
+						pagetime.append("time_start", "'.$token_array['time_start'].'");
+						pagetime.append("token", "'.$token.'");
+						pagetime.append("time", time_end-time_start);
+						pagetime.append("ajax", "1");
+						navigator.sendBeacon("'.Context::getContext()->link->getPageLink('statistics', (bool)(Tools::getShopProtocol() == 'https://')).'", pagetime);
 					}
 				);
 			</script>';

--- a/statsdata.php
+++ b/statsdata.php
@@ -137,13 +137,13 @@ class statsdata extends Module
 						var time_end = new Date();
 						var pagetime = new FormData();
 						pagetime.append("type", "pagetime");
-						pagetime.append("id_connections", "'.(int)$token_array['id_connections'].'");
-						pagetime.append("id_page", "'.(int)$token_array['id_page'].'");
-						pagetime.append("time_start", "'.$token_array['time_start'].'");
-						pagetime.append("token", "'.$token.'");
+						pagetime.append("id_connections", "' . (int) $token_array['id_connections'] . '");
+						pagetime.append("id_page", "' . (int) $token_array['id_page'] . '");
+						pagetime.append("time_start", "' . $token_array['time_start'] . '");
+						pagetime.append("token", "' . $token . '");
 						pagetime.append("time", time_end-time_start);
 						pagetime.append("ajax", "1");
-						navigator.sendBeacon("'.Context::getContext()->link->getPageLink('statistics', (bool)(Tools::getShopProtocol() == 'https://')).'", pagetime);
+						navigator.sendBeacon("' . Context::getContext()->link->getPageLink('statistics', (bool) (Tools::getShopProtocol() == 'https://')) . '", pagetime);
 					}
 				);
 			</script>';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The statsdata module calls StatisticsController to save the statistics without the "ajax" parameter and generates an error
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#20921.
| How to test?  | BO: configure statsdata module and save page views for each customer and ave global page views options. FO: open console > network tab > select the "Preserve log" option, reload the page and see error.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Hello @matks,

Here is the PR to replace this one PrestaShop/Prestashop#26963