### PR TITLE
Stop using deprecated hook

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>statsdata</name>
 	<displayName><![CDATA[Data mining for statistics]]></displayName>
-	<version><![CDATA[2.1.1]]></version>
+	<version><![CDATA[2.1.2]]></version>
 	<description><![CDATA[This module must be enabled if you want to use statistics.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[analytics_stats]]></tab>

--- a/statsdata.php
+++ b/statsdata.php
@@ -33,7 +33,7 @@ class statsdata extends Module
     {
         $this->name = 'statsdata';
         $this->tab = 'administration';
-        $this->version = '2.1.1';
+        $this->version = '2.1.2';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 

--- a/statsdata.php
+++ b/statsdata.php
@@ -42,7 +42,7 @@ class statsdata extends Module
 
         $this->displayName = $this->trans('Data mining for statistics', [], 'Modules.Statsdata.Admin');
         $this->description = $this->trans('Collect as much information as possible to enrich your stats and run your business further.', [], 'Modules.Statsdata.Admin');
-        $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.8.10', 'max' => _PS_VERSION_];
     }
 
     public function install()

--- a/statsdata.php
+++ b/statsdata.php
@@ -50,7 +50,7 @@ class statsdata extends Module
         return parent::install()
             && $this->registerHook('displayBeforeBodyClosingTag')
             && $this->registerHook('actionAuthentication')
-            && $this->registerHook('createAccount');
+            && $this->registerHook('actionCustomerAccountAdd');
     }
 
     public function getContent()
@@ -148,7 +148,7 @@ class statsdata extends Module
         return '';
     }
 
-    public function hookCreateAccount($params)
+    public function hookActionCustomerAccountAdd($params)
     {
         return $this->hookActionAuthentication($params);
     }

--- a/statsdata.php
+++ b/statsdata.php
@@ -42,7 +42,7 @@ class statsdata extends Module
 
         $this->displayName = $this->trans('Data mining for statistics', [], 'Modules.Statsdata.Admin');
         $this->description = $this->trans('Collect as much information as possible to enrich your stats and run your business further.', [], 'Modules.Statsdata.Admin');
-        $this->ps_versions_compliancy = ['min' => '1.7.8.10', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
     }
 
     public function install()

--- a/upgrade/upgrade-2.1.2.php
+++ b/upgrade/upgrade-2.1.2.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_1_2($module)
+{
+    $module->unregisterHook('createAccount');
+    $module->registerHook('actionCustomerAccountAdd');
+
+    return true;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Module is using an outdated hook. Using an alias throws a deprecated message in logs. The hook "createAccount" is deprecated, please use "actionCustomerAccountAdd" instead in module "statsdata".
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Please indicate how to best verify that this PR is correct.

### Example of errors

```
[proxy_fcgi:error] [pid 29439:tid 35444818688] [remote 0.0.0.0:9822] AH01071:
Got error 'PHP message: PHP Deprecated: 
The hook "createAccount" is deprecated, please use "actionCustomerAccountAdd" instead in module "statsdata". in /usr/local/www/mysite.com/www/classes/Hook.php on line 914
```