### PR TITLE
check for Guest validity in hookActionAuthentication

### DIFF
--- a/statsdata.php
+++ b/statsdata.php
@@ -157,6 +157,10 @@ class statsdata extends Module
     {
         // Update or merge the guest with the customer id (login and account creation)
         $guest = new Guest($params['cookie']->id_guest);
+        //Sometimes the id_guest in the cookie is empty / invalid or old here (it has been deleted already), so we should interrupt here in that case
+        if (!Validate::isLoadedObject($guest)){
+            return;
+        }
         $result = Db::getInstance()->getRow('
 		SELECT `id_guest`
 		FROM `' . _DB_PREFIX_ . 'guest`


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Sometimes the id_guest property of the cookie object retrieved from the hookActionAuthentication function is empty / invalid or just old. This can happen easily if the same guest submits the login form with valid data on the front office twice or more while being unlogged (he could simply click 2+ times on the login button for example), so the login procedure will succeed N times in N different php processes, and so the hookActionAuthentication function will be fired N times while containing the same id_guest: the issue here lies within the `$guest->mergeWithCustomer()` function call, which if it's called with an empty Guest object, it will execute this query: `Db::getInstance()->update('cart', ['id_guest' => (int) $idGuest,], 'id_guest = ' . (int) $this->id);` where `$this->id` will be equal to zero due to the fact that the same Guest object got deleted during the first login procedure by calling `$guest->mergeWithCustomer()`. That UPDATE query will set an id_guest for every cart in the database having id_guest = 0. Carts that have the id_guest set to 0 are temporary carts created from the Order creation page in the Backfofice. With this PR I'm proposing to check the validity of the Guest object before proceeeding to execute the hookActionAuthentication logic.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
